### PR TITLE
metadata-change - x264 cookbook's version

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -7,7 +7,7 @@ version          "0.2.0"
 
 supports "ubuntu", "10.04"
 
-depends "x264", "~> 0.2.0"
+depends "x264", "~> 0.3.0"
 depends "libvpx", "~> 0.2.0"
 depends "build-essential"
 depends "git"


### PR DESCRIPTION
Hi,

I've made a small change to the cookbook's metadata so that x264 version 0.3.0 can be used as well.
Let me know if you have any questions or remarks - thanks in advance!

Kind regards,
David
