### PR TITLE
Allow re-compilation when source or compile flags change

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -7,7 +7,7 @@ version          "0.2.1"
 
 supports "ubuntu", "10.04"
 
-depends "x264", "~> 0.3.0"
+depends "x264", "~> 0.2.0"
 depends "libvpx", "~> 0.2.0"
 depends "build-essential"
 depends "git"

--- a/recipes/source.rb
+++ b/recipes/source.rb
@@ -61,7 +61,7 @@ git "#{Chef::Config[:file_cache_path]}/ffmpeg" do
   repository node[:ffmpeg][:git_repository]
   reference node[:ffmpeg][:git_revision]
   action :sync
-  notifies :delete, "file[#{creates_ffmpeg}]"
+  notifies :delete, "file[#{creates_ffmpeg}]", :immediately
 end
 
 # Write the flags used to compile the application to Disk. If the flags
@@ -74,7 +74,7 @@ template "#{Chef::Config[:file_cache_path]}/ffmpeg-compiled_with_flags" do
   variables(
     :compile_flags => node[:ffmpeg][:compile_flags]
   )
-  notifies :delete, "file[#{creates_ffmpeg}]"
+  notifies :delete, "file[#{creates_ffmpeg}]", :immediately
 end
 
 bash "compile_ffmpeg" do

--- a/recipes/source.rb
+++ b/recipes/source.rb
@@ -51,11 +51,17 @@ find_prerequisite_packages_by_flags(flags_for_upgrade).each do |pkg|
   end
 end
 
+creates_ffmpeg = "#{node[:ffmpeg][:prefix]}/bin/ffmpeg"
+
+file "#{creates_ffmpeg}" do
+	action :nothing
+end
+
 git "#{Chef::Config[:file_cache_path]}/ffmpeg" do
   repository node[:ffmpeg][:git_repository]
   reference node[:ffmpeg][:git_revision]
   action :sync
-  notifies :run, "bash[compile_ffmpeg]"
+  notifies :delete, "file[#{creates_ffmpeg}]"
 end
 
 # Write the flags used to compile the application to Disk. If the flags
@@ -68,7 +74,7 @@ template "#{Chef::Config[:file_cache_path]}/ffmpeg-compiled_with_flags" do
   variables(
     :compile_flags => node[:ffmpeg][:compile_flags]
   )
-  notifies :run, "bash[compile_ffmpeg]"
+  notifies :delete, "file[#{creates_ffmpeg}]"
 end
 
 bash "compile_ffmpeg" do
@@ -77,5 +83,5 @@ bash "compile_ffmpeg" do
     ./configure --prefix=#{node[:ffmpeg][:prefix]} #{node[:ffmpeg][:compile_flags].join(' ')}
     make clean && make && make install
   EOH
-  action :nothing
+  creates "#{creates_ffmpeg}"
 end

--- a/recipes/source.rb
+++ b/recipes/source.rb
@@ -77,5 +77,5 @@ bash "compile_ffmpeg" do
     ./configure --prefix=#{node[:ffmpeg][:prefix]} #{node[:ffmpeg][:compile_flags].join(' ')}
     make clean && make && make install
   EOH
-  creates "#{node[:ffmpeg][:prefix]}/bin/ffmpeg"
+  action :nothing
 end


### PR DESCRIPTION
Hi,

when making use of "creates" no recompilation is triggered when new code is pulled down nor when compile flags change. Via action :nothing the compile is triggered via the notifies :run.

Let me know if you have any questions or comments, thanks in advance!

Kind regards,
David
