### PR TITLE
Add Amazon Linux support

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -21,7 +21,7 @@
 
 default[:ffmpeg][:install_method] = :source
 default[:ffmpeg][:prefix] = "/usr/local"
-default[:ffmpeg][:git_repository] = "git://git.videolan.org/ffmpeg.git"
+default[:ffmpeg][:git_repository] = "git://source.ffmpeg.org/ffmpeg.git"
 default[:ffmpeg][:compile_flags] = [
   "--disable-debug",
   "--enable-pthreads",

--- a/metadata.rb
+++ b/metadata.rb
@@ -1,6 +1,7 @@
 maintainer       "En Masse Entertainment"
 maintainer_email "jamie@vialstudios.com"
 license          "Apache 2.0"
+name             "ffmpeg"
 description      "Installs and configures FFMPEG from source or package"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          "0.2.1"

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,8 +6,10 @@ long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          "0.2.1"
 
 supports "ubuntu", "10.04"
+supports "amazon"
 
 depends "x264", "~> 0.3.0"
 depends "libvpx", "~> 0.2.0"
 depends "build-essential"
 depends "git"
+depends "yasm"

--- a/metadata.rb
+++ b/metadata.rb
@@ -7,7 +7,7 @@ long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          "0.2.1"
 
 supports "ubuntu", "10.04"
-supports "amazon"
+supports "amazon", "2012.09"
 
 depends "x264", "~> 0.3.0"
 depends "libvpx", "~> 0.2.0"

--- a/providers/module.rb
+++ b/providers/module.rb
@@ -68,7 +68,7 @@ action :install do
         make install
       EOH
       not_if {!new_resource.creates.nil? && ::File.exist?(new_resource.creates)}
-      notifies :create, "ruby_block[notify_updated_#{new_resource.name}]"
+      notifies :create, "ruby_block[notify_updated_#{new_resource.name}]", :immediately
     end
   end
 

--- a/providers/module.rb
+++ b/providers/module.rb
@@ -1,0 +1,73 @@
+#
+# Cookbook Name:: ffmpeg
+# Provider:: module
+#
+# Author:: iuri aranda (<iuri.aranda@uwhisp.com>)
+#
+# Copyright 2011, En Masse Entertainment, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+action :install do
+  case new_resource.install_method
+  when 'package'
+    package new_resource.name do
+      action :install
+      notifies :create, "ruby_block[notify_updated_#{new_resource.name}]", :immediately
+    end
+  else
+    file = new_resource.source.split('/').last
+    remote_file "#{Chef::Config[:file_cache_path]}/#{file}" do
+      mode 00644
+      source new_resource.source
+      notifies :run, "bash[install_#{new_resource.name}]", :immediately
+    end
+
+    # Write the flags used to compile the application to Disk. If the flags
+    # do not match those that are in the compiled_flags attribute - we recompile
+    template "#{Chef::Config[:file_cache_path]}/#{new_resource.name}-compiled_with_flags" do
+      source "compiled_with_flags.erb"
+      owner "root"
+      group "root"
+      mode 0600
+      variables(
+        :compile_flags => new_resource.compile_flags
+      )
+      notifies :run, "bash[install_#{new_resource.name}]", :immediately
+    end
+
+    install = bash "install_#{new_resource.name}" do
+      user "root"
+      cwd Chef::Config[:file_cache_path]
+      code <<-EOH
+        tar -zxf #{file}
+        cd #{file.strip.gsub(/\.tar\.gz/, "").gsub(/\.tgz/, "")}
+        ./configure #{new_resource.compile_flags.join(' ')}
+        make
+        make install
+      EOH
+      action :nothing
+      notifies :create, "ruby_block[notify_updated_#{new_resource.name}]", :immediately
+    end
+
+    install.run_action(:run) unless !new_resource.creates.nil? && ::File.exist?(new_resource.creates)
+  end
+
+  ruby_block "notify_updated_#{new_resource.name}" do
+    block do
+      new_resource.updated_by_last_action(true)
+    end
+    action :nothing
+  end
+end

--- a/recipes/dependencies.rb
+++ b/recipes/dependencies.rb
@@ -1,0 +1,69 @@
+#
+# Cookbook Name:: ffmpeg
+# Recipe:: dependencies
+#
+# Author:: iuri aranda (<iuri.aranda@uwhisp.com>)
+#
+# Copyright 2011, En Masse Entertainment, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+include_recipe "build-essential"
+include_recipe "git"
+
+case node[:platform]
+when "debian","ubuntu"
+  include_recipe "yasm::package"
+else
+  include_recipe "yasm::source"
+end
+
+Chef::Log.debug("ffmpeg compile flags #{node[:ffmpeg][:compile_flags].join(', ')}")
+
+# Filter the packages that we just built from source via their compile flag
+node[:ffmpeg][:compile_flags].each do |flag|
+  case flag
+  when "--enable-libx264"
+    include_recipe "x264::source"
+  when "--enable-libvpx"
+    include_recipe "libvpx::source"
+  when "--enable-libmp3lame"
+    ffmpeg_module "libmp3lame" do
+      source "http://downloads.sourceforge.net/project/lame/lame/3.99/lame-3.99.5.tar.gz"
+      compile_flags [
+        "--disable-shared",
+        "--enable-nasm"
+      ]
+      creates "/usr/local/lib/libmp3lame.a"
+    end
+  when "--enable-libvorbis"
+    # Libvorbis needs two modules to be installed
+    ffmpeg_module "libogg" do
+      source "http://downloads.xiph.org/releases/ogg/libogg-1.3.0.tar.gz"
+      compile_flags ["--disable-shared"]
+      creates "/usr/local/lib/libogg.a"
+    end
+    ffmpeg_module "libvorbis" do
+      source "http://downloads.xiph.org/releases/vorbis/libvorbis-1.3.3.tar.gz"
+      compile_flags ["--disable-shared"]
+      creates "/usr/local/lib/libvorbis.a"
+    end
+  else
+    packages_for_flag(flag).each do |pkg|
+      package pkg do
+        action :upgrade
+      end
+    end
+  end
+end

--- a/recipes/source.rb
+++ b/recipes/source.rb
@@ -19,35 +19,13 @@
 # limitations under the License.
 #
 
-include_recipe "build-essential"
-include_recipe "git"
-
 ffmpeg_packages.each do |pkg|
   package pkg do
     action :purge
   end
 end
 
-include_recipe "x264::source"
-include_recipe "libvpx::source"
-
-case node['platform']
-when "debian","ubuntu"
-  include_recipe "yasm::package"
-else
-  include_recipe "yasm::source"
-end
-
-# Filter the packages that we just built from source via their compile flag
-flags_for_upgrade = node[:ffmpeg][:compile_flags].reject do |flag|
-  ["--enable-libx264", "--enable-libvpx"].include?(flag)
-end
-
-find_prerequisite_packages_by_flags(flags_for_upgrade).each do |pkg|
-  package pkg do
-    action :upgrade
-  end
-end
+include_recipe "ffmpeg::dependencies"
 
 git "#{Chef::Config[:file_cache_path]}/ffmpeg" do
   repository node[:ffmpeg][:git_repository]

--- a/recipes/source.rb
+++ b/recipes/source.rb
@@ -31,17 +31,15 @@ end
 include_recipe "x264::source"
 include_recipe "libvpx::source"
 
-yasm_package = value_for_platform(
-  [ "ubuntu" ] => { "default" => "yasm" },
-  "default" => "yasm"
-)
-
-package yasm_package do
-  action :upgrade
+case node['platform']
+when "debian","ubuntu"
+  include_recipe "yasm::package"
+else
+  include_recipe "yasm::source"
 end
 
 # Filter the packages that we just built from source via their compile flag
-flags_for_upgrade = node[:ffmpeg][:compile_flags].reject do |flag| 
+flags_for_upgrade = node[:ffmpeg][:compile_flags].reject do |flag|
   ["--enable-libx264", "--enable-libvpx"].include?(flag)
 end
 

--- a/recipes/source.rb
+++ b/recipes/source.rb
@@ -27,11 +27,18 @@ end
 
 include_recipe "ffmpeg::dependencies"
 
+# File resource needed to delete the ffmpeg binary file to trigger the build when something changes
+creates = "#{node[:ffmpeg][:prefix]}/bin/ffmpeg"
+file creates do
+  action :nothing
+end
+
 git "#{Chef::Config[:file_cache_path]}/ffmpeg" do
   repository node[:ffmpeg][:git_repository]
   reference node[:ffmpeg][:git_revision]
   action :sync
-  notifies :run, "bash[compile_ffmpeg]"
+  # Delete ffmpeg binary file to trigger the build
+  notifies :delete, "file[#{creates}]", :immediately
 end
 
 # Write the flags used to compile the application to Disk. If the flags
@@ -44,7 +51,8 @@ template "#{Chef::Config[:file_cache_path]}/ffmpeg-compiled_with_flags" do
   variables(
     :compile_flags => node[:ffmpeg][:compile_flags]
   )
-  notifies :run, "bash[compile_ffmpeg]"
+  # Delete ffmpeg binary file to trigger the build
+  notifies :delete, "file[#{creates}]", :immediately
 end
 
 bash "compile_ffmpeg" do
@@ -53,5 +61,5 @@ bash "compile_ffmpeg" do
     ./configure --prefix=#{node[:ffmpeg][:prefix]} #{node[:ffmpeg][:compile_flags].join(' ')}
     make clean && make && make install
   EOH
-  creates "#{node[:ffmpeg][:prefix]}/bin/ffmpeg"
+  not_if {::File.exist?(creates)}
 end

--- a/resources/module.rb
+++ b/resources/module.rb
@@ -1,0 +1,28 @@
+#
+# Cookbook Name:: ffmpeg
+# Resource:: module
+#
+# Author:: iuri aranda (<iuri.aranda@uwhisp.com>)
+#
+# Copyright 2011, En Masse Entertainment, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+actions :install
+default_action :install
+
+attribute :install_method,  :kind_of => String, :default => 'source'
+attribute :source,          :kind_of => String, :default => nil
+attribute :compile_flags,   :kind_of => Array,  :default => ''
+attribute :creates,         :kind_of => String, :default => nil


### PR DESCRIPTION
- Added support for Amazon Linux platform. Tested on 2012.09 version.
  Amazon Linux does not provide ffmpeg yum packages, so they have to be installed from source (ffmpeg and its dependencies). So I've added an LWRP provider that installs an ffmpeg module given its source url and compile flags. These modules are installed or not depending on the ffmpeg compile_flags (as before).
- Changed the ffmpeg git repo to the new one `git://source.ffmpeg.org/ffmpeg.git`
- Added cookbook `ffmpeg` name in metadata
