### PR TITLE
Allow :install_method to be configured from json (string)

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -19,7 +19,7 @@
 # limitations under the License.
 #
 
-case node[:ffmpeg][:install_method]
+case node[:ffmpeg][:install_method].to_sym
 when :source
   include_recipe "ffmpeg::source"
 when :package


### PR DESCRIPTION
Allows `:install_method` to be configured from /nodes/nodename.json
Example:

```
  "ffmpeg":{
    "install_method": "package"
  }
```
