### PR TITLE
Stop forcing x264/libpvx to install from source

### DIFF
--- a/recipes/source.rb
+++ b/recipes/source.rb
@@ -14,8 +14,8 @@ ffmpeg_packages.each do |pkg|
     end
 end
 
-include_recipe "x264::source"
-include_recipe "libvpx::source"
+include_recipe "x264"
+include_recipe "libvpx"
 
 yasm_package = value_for_platform(
     [ "ubuntu" ] => { "default" => "yasm" },
@@ -27,7 +27,7 @@ package yasm_package do
 end
 
 # Filter the packages that we just built from source via their compile flag
-flags_for_upgrade = node['ffmpeg']['compile_flags'].reject do |flag| 
+flags_for_upgrade = node['ffmpeg']['compile_flags'].reject do |flag|
     ["--enable-libx264", "--enable-libvpx"].include?(flag)
 end
 


### PR DESCRIPTION
Explicitly invoking the source recipes for these dependencies is pointless as their default attributes set the install method as source anyway.

There are some use cases where installing these dependencies as packages is desired. Invoking the default recipes allows users to control this by overriding the attributes for the respective dependencies.
