### PR TITLE
Add name setting to metadata.rb

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -1,3 +1,4 @@
+name             "ffmpeg"
 maintainer       "David Joos"
 maintainer_email "development@davidjoos.com"
 license          "MIT"


### PR DESCRIPTION
It's not required to have a name setting in the metadata file, but it's best practice to and some libraries require it.
