### PR TITLE
Ignore failures in package purging

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -15,7 +15,6 @@ default['ffmpeg']['compile_flags'] = [
   "--enable-gpl",
   "--disable-indev=jack",
   "--enable-libx264",
-  "--enable-libfaac",
   "--enable-libmp3lame",
   "--enable-libtheora",
   "--enable-libvorbis",

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -20,7 +20,6 @@ default['ffmpeg']['compile_flags'] = [
   "--enable-libvorbis",
   "--enable-libvpx",
   "--enable-libxvid",
-  "--enable-libfaad"
 ]
 
 # JW 07-06-11: Hash of commit or a HEAD should be used - not a tag. Sync action of Git

--- a/recipes/source.rb
+++ b/recipes/source.rb
@@ -11,6 +11,7 @@ include_recipe "git"
 ffmpeg_packages.each do |pkg|
     package pkg do
         action :purge
+        ignore_failure true
     end
 end
 


### PR DESCRIPTION
This was breaking our chef run. Basically, if you install from source and had never install from a package first, the package resource with action purge fails and the run breaks.
